### PR TITLE
Add NeMo CTC English models to the auto-download registry

### DIFF
--- a/ASR_MODEL.md
+++ b/ASR_MODEL.md
@@ -49,7 +49,8 @@ Use these with `--offline`. Audio is VAD-segmented before recognition, which usu
 | Whisper medium.en | `models/sherpa-onnx-whisper-medium.en` | `whisper` | en | Higher accuracy |
 | Whisper large-v3 | `models/sherpa-onnx-whisper-large-v3` | `whisper` | multi | Multilingual; **auto-downloaded** when `--model-dir` matches; ~3 GB; use `--language` |
 | Paraformer ZH | `models/sherpa-onnx-paraformer-zh-2023-09-14` | `paraformer` | zh | |
-| NeMo CTC En | `models/sherpa-onnx-nemo-ctc-en-conformer-medium` | `nemo_ctc` | en | NeMo Conformer CTC |
+| NeMo CTC En (medium) | `models/sherpa-onnx-nemo-ctc-en-conformer-medium` | `nemo_ctc` | en | **Auto-downloaded** when selected; NeMo Conformer CTC; exposes per-word confidence |
+| NeMo CTC En (small) | `models/sherpa-onnx-nemo-ctc-en-conformer-small` | `nemo_ctc` | en | **Auto-downloaded** when `--model-dir` matches; lighter/faster variant |
 | SenseVoice | `models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17` | `sense_voice` | multi | 5 languages; **auto-downloaded**; use `--language` |
 | Moonshine tiny | `models/sherpa-onnx-moonshine-tiny-en-int8` | `moonshine` | en | Very fast, English only |
 | Moonshine base | `models/sherpa-onnx-moonshine-base-en-int8` | `moonshine` | en | Better accuracy than tiny |
@@ -102,6 +103,13 @@ sherox.asr --wav audio.wav --lang de
 # German NeMo CTC (offline, auto-downloaded, default for --lang de --offline)
 sherox.asr --mic --lang de --offline
 sherox.asr --wav audio.wav --lang de --offline
+
+# NeMo CTC English (offline, auto-downloaded); per-word confidence via CTC posteriors
+sherox.asr --wav audio.wav --offline --model-type nemo_ctc --language en
+
+# NeMo CTC English, lighter/faster variant (auto-downloaded via --model-dir)
+sherox.asr --wav audio.wav --offline --model-type nemo_ctc \
+  --model-dir models/sherpa-onnx-nemo-ctc-en-conformer-small
 
 # ReazonSpeech Japanese (auto-downloaded)
 sherox.asr --mic --model-type reazonspeech-ja

--- a/sherox/asr.py
+++ b/sherox/asr.py
@@ -457,6 +457,27 @@ _PARAKEET_CTC_JA_INT8_ARCHIVE = "sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000
 _PARAKEET_CTC_JA_INT8_EXTRACTED = "sherpa-onnx-nemo-parakeet-tdt_ctc-0.6b-ja-35000-int8"
 _PARAKEET_CTC_JA_INT8_TARGET = "parakeet-ctc-ja-int8"
 
+# ── NeMo CTC English model URLs ────────────────────────────────────────────────
+# English NeMo Conformer CTC model (~158 MB). Auto-download default for
+# `--model-type nemo_ctc --language en`; exposes per-word confidence via CTC
+# token posteriors, unlike the Parakeet transducer default.
+_NEMO_CTC_EN_MEDIUM_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+    "asr-models/sherpa-onnx-nemo-ctc-en-conformer-medium.tar.bz2"
+)
+_NEMO_CTC_EN_MEDIUM_ARCHIVE = "sherpa-onnx-nemo-ctc-en-conformer-medium.tar.bz2"
+_NEMO_CTC_EN_MEDIUM_EXTRACTED = "sherpa-onnx-nemo-ctc-en-conformer-medium"
+_NEMO_CTC_EN_MEDIUM_TARGET = "sherpa-onnx-nemo-ctc-en-conformer-medium"
+
+# Lighter variant; select by passing --model-dir models/<small target> explicitly.
+_NEMO_CTC_EN_SMALL_URL = (
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/"
+    "asr-models/sherpa-onnx-nemo-ctc-en-conformer-small.tar.bz2"
+)
+_NEMO_CTC_EN_SMALL_ARCHIVE = "sherpa-onnx-nemo-ctc-en-conformer-small.tar.bz2"
+_NEMO_CTC_EN_SMALL_EXTRACTED = "sherpa-onnx-nemo-ctc-en-conformer-small"
+_NEMO_CTC_EN_SMALL_TARGET = "sherpa-onnx-nemo-ctc-en-conformer-small"
+
 # ── Cohere Transcribe model URLs ──────────────────────────────────────────────
 # Multilingual model supporting 14 languages
 # (https://huggingface.co/CohereLabs/cohere-transcribe-03-2026)
@@ -667,6 +688,15 @@ def _download_model(model_dir: str, model_type: str) -> None:
         url = _GERMAN_NEMO_URL
         archive_name = _GERMAN_NEMO_ARCHIVE
         extracted_name = _GERMAN_NEMO_EXTRACTED
+    # NeMo CTC English models (medium is the auto-download default; small is opt-in)
+    elif model_dir.name == _NEMO_CTC_EN_MEDIUM_TARGET:
+        url = _NEMO_CTC_EN_MEDIUM_URL
+        archive_name = _NEMO_CTC_EN_MEDIUM_ARCHIVE
+        extracted_name = _NEMO_CTC_EN_MEDIUM_EXTRACTED
+    elif model_dir.name == _NEMO_CTC_EN_SMALL_TARGET:
+        url = _NEMO_CTC_EN_SMALL_URL
+        archive_name = _NEMO_CTC_EN_SMALL_ARCHIVE
+        extracted_name = _NEMO_CTC_EN_SMALL_EXTRACTED
     # Use parakeet as the default offline model download target
     elif model_type == "nemo_transducer" or model_dir.name in (
         _PARAKEET_FP16_TARGET, _PARAKEET_INT8_TARGET
@@ -747,6 +777,10 @@ def _resolve_default_model(language: str, model_type: str, offline: bool) -> tup
         return model_type, _MULTILINGUAL_STREAMING_TARGET
     if model_type == "nemo_transducer":
         return model_type, _PARAKEET_TARGET
+    if model_type == "nemo_ctc":
+        if language == "de":
+            return model_type, _GERMAN_NEMO_TARGET
+        return model_type, _NEMO_CTC_EN_MEDIUM_TARGET
     if model_type:
         return model_type, _PARAKEET_TARGET if offline else _MODEL_TARGET
     # German: online uses streaming zipformer, offline uses NeMo CTC

--- a/sherox/asr.py
+++ b/sherox/asr.py
@@ -688,15 +688,17 @@ def _download_model(model_dir: str, model_type: str) -> None:
         url = _GERMAN_NEMO_URL
         archive_name = _GERMAN_NEMO_ARCHIVE
         extracted_name = _GERMAN_NEMO_EXTRACTED
-    # NeMo CTC English models (medium is the auto-download default; small is opt-in)
-    elif model_dir.name == _NEMO_CTC_EN_MEDIUM_TARGET:
-        url = _NEMO_CTC_EN_MEDIUM_URL
-        archive_name = _NEMO_CTC_EN_MEDIUM_ARCHIVE
-        extracted_name = _NEMO_CTC_EN_MEDIUM_EXTRACTED
+    # NeMo CTC English models (medium is the auto-download default; small is opt-in).
+    # Check the small target by name first so an explicit small --model-dir isn't
+    # shadowed by the nemo_ctc model_type fallback below.
     elif model_dir.name == _NEMO_CTC_EN_SMALL_TARGET:
         url = _NEMO_CTC_EN_SMALL_URL
         archive_name = _NEMO_CTC_EN_SMALL_ARCHIVE
         extracted_name = _NEMO_CTC_EN_SMALL_EXTRACTED
+    elif model_type == "nemo_ctc" or model_dir.name == _NEMO_CTC_EN_MEDIUM_TARGET:
+        url = _NEMO_CTC_EN_MEDIUM_URL
+        archive_name = _NEMO_CTC_EN_MEDIUM_ARCHIVE
+        extracted_name = _NEMO_CTC_EN_MEDIUM_EXTRACTED
     # Use parakeet as the default offline model download target
     elif model_type == "nemo_transducer" or model_dir.name in (
         _PARAKEET_FP16_TARGET, _PARAKEET_INT8_TARGET

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -535,10 +535,10 @@ def _extracted_name_for(model_dir_name: str, model_type: str) -> str:
         return main_module._WHISPER_DISTIL_LARGE_V35_EXTRACTED
     if model_type == "multilingual_streaming" or model_dir_name == main_module._MULTILINGUAL_STREAMING_TARGET:
         return main_module._MULTILINGUAL_STREAMING_EXTRACTED
-    if model_dir_name == main_module._NEMO_CTC_EN_MEDIUM_TARGET:
-        return main_module._NEMO_CTC_EN_MEDIUM_EXTRACTED
     if model_dir_name == main_module._NEMO_CTC_EN_SMALL_TARGET:
         return main_module._NEMO_CTC_EN_SMALL_EXTRACTED
+    if model_type == "nemo_ctc" or model_dir_name == main_module._NEMO_CTC_EN_MEDIUM_TARGET:
+        return main_module._NEMO_CTC_EN_MEDIUM_EXTRACTED
     if model_type == "nemo_transducer" or model_dir_name in (
         main_module._PARAKEET_FP16_TARGET,
         main_module._PARAKEET_INT8_TARGET,
@@ -664,6 +664,16 @@ class TestDownloadModel:
         medium_url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_MEDIUM_TARGET, "nemo_ctc")
         small_url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_SMALL_TARGET, "nemo_ctc")
         assert medium_url != small_url
+
+    def test_uses_nemo_ctc_en_medium_url_for_custom_dir_name_with_nemo_ctc_type(self, tmp_path):
+        # A non-canonical --model-dir combined with --model-type nemo_ctc must still
+        # resolve to the English CTC model, not the unrelated default fallback.
+        url = _run_download_model(tmp_path, "my-custom-ctc-model", "nemo_ctc")
+        assert "nemo-ctc-en-conformer-medium" in url
+
+    def test_nemo_ctc_type_does_not_shadow_small_target_dir_name(self, tmp_path):
+        url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_SMALL_TARGET, "nemo_ctc")
+        assert "nemo-ctc-en-conformer-small" in url
 
 
 # ---------------------------------------------------------------------------
@@ -1413,6 +1423,26 @@ class TestMain:
 
         called_dir, called_type = mock_vm.call_args[0]
         assert Path(called_dir).name == main_module._NEMO_CTC_EN_MEDIUM_TARGET
+        assert called_type == "nemo_ctc"
+
+    def test_nemo_ctc_model_type_with_german_lang_uses_german_target(self):
+        args = self._common_patches(None, model_type="nemo_ctc", offline=True)
+        args.language = "de"
+        mock_rec = MagicMock()
+
+        with patch.object(main_module, "parse_args", return_value=args), \
+             patch.object(main_module, "_validate_runtime_args"), \
+             patch.object(main_module, "_validate_model") as mock_vm, \
+             patch.object(main_module, "_validate_vad", return_value="models/silero_vad.onnx"), \
+             patch.object(main_module, "_validate_mic"), \
+             patch("sherox.asr.build_offline_recognizer", return_value=mock_rec), \
+             patch("sherox.asr.build_vad", return_value=MagicMock()), \
+             patch("sherox.asr.mic_stream", return_value=iter([])), \
+             patch("sherox.asr.run_offline_vad_streaming"):
+            main_module.main()
+
+        called_dir, called_type = mock_vm.call_args[0]
+        assert Path(called_dir).name == main_module._GERMAN_NEMO_TARGET
         assert called_type == "nemo_ctc"
 
     def test_online_with_diarization(self):

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -535,6 +535,10 @@ def _extracted_name_for(model_dir_name: str, model_type: str) -> str:
         return main_module._WHISPER_DISTIL_LARGE_V35_EXTRACTED
     if model_type == "multilingual_streaming" or model_dir_name == main_module._MULTILINGUAL_STREAMING_TARGET:
         return main_module._MULTILINGUAL_STREAMING_EXTRACTED
+    if model_dir_name == main_module._NEMO_CTC_EN_MEDIUM_TARGET:
+        return main_module._NEMO_CTC_EN_MEDIUM_EXTRACTED
+    if model_dir_name == main_module._NEMO_CTC_EN_SMALL_TARGET:
+        return main_module._NEMO_CTC_EN_SMALL_EXTRACTED
     if model_type == "nemo_transducer" or model_dir_name in (
         main_module._PARAKEET_FP16_TARGET,
         main_module._PARAKEET_INT8_TARGET,
@@ -647,6 +651,19 @@ class TestDownloadModel:
         url = _run_download_model(tmp_path, main_module._PARAKEET_CTC_JA_INT8_TARGET, "")
         assert "parakeet" in url
         assert "ja" in url
+
+    def test_uses_nemo_ctc_en_medium_url_for_medium_dir_name(self, tmp_path):
+        url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_MEDIUM_TARGET, "nemo_ctc")
+        assert "nemo-ctc-en-conformer-medium" in url
+
+    def test_uses_nemo_ctc_en_small_url_for_small_dir_name(self, tmp_path):
+        url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_SMALL_TARGET, "nemo_ctc")
+        assert "nemo-ctc-en-conformer-small" in url
+
+    def test_nemo_ctc_en_medium_and_small_use_different_urls(self, tmp_path):
+        medium_url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_MEDIUM_TARGET, "nemo_ctc")
+        small_url = _run_download_model(tmp_path, main_module._NEMO_CTC_EN_SMALL_TARGET, "nemo_ctc")
+        assert medium_url != small_url
 
 
 # ---------------------------------------------------------------------------
@@ -1378,6 +1395,25 @@ class TestMain:
         called_dir, called_type = mock_vm.call_args[0]
         assert Path(called_dir).name == main_module._PARAKEET_INT8_TARGET
         assert called_type == "nemo_transducer"
+
+    def test_nemo_ctc_model_type_uses_english_ctc_default_model(self):
+        args = self._common_patches(None, model_type="nemo_ctc", offline=True)
+        mock_rec = MagicMock()
+
+        with patch.object(main_module, "parse_args", return_value=args), \
+             patch.object(main_module, "_validate_runtime_args"), \
+             patch.object(main_module, "_validate_model") as mock_vm, \
+             patch.object(main_module, "_validate_vad", return_value="models/silero_vad.onnx"), \
+             patch.object(main_module, "_validate_mic"), \
+             patch("sherox.asr.build_offline_recognizer", return_value=mock_rec), \
+             patch("sherox.asr.build_vad", return_value=MagicMock()), \
+             patch("sherox.asr.mic_stream", return_value=iter([])), \
+             patch("sherox.asr.run_offline_vad_streaming"):
+            main_module.main()
+
+        called_dir, called_type = mock_vm.call_args[0]
+        assert Path(called_dir).name == main_module._NEMO_CTC_EN_MEDIUM_TARGET
+        assert called_type == "nemo_ctc"
 
     def test_online_with_diarization(self):
         args = self._common_patches(


### PR DESCRIPTION
## Summary
- Adds `sherpa-onnx-nemo-ctc-en-conformer-medium` (auto-download default) and `-small` (opt-in via `--model-dir`) NeMo CTC English models to `sherox/asr.py`, following the existing `_PARAKEET_*` constants pattern.
- Wires both into the `_download_model` dispatcher (matched by target directory name, same as the existing German NeMo CTC entry) and into `_resolve_default_model` so `--model-type nemo_ctc` picks the right default per language (English medium CTC by default, German target when `--lang de`).
- Marks both rows as **auto** in `ASR_MODEL.md` and adds usage examples.

This lets a CTC English model be used as the default ASR model type without a manual download step, giving per-word confidence via CTC token posteriors — needed by a downstream pronunciation scorer that blends phoneme edit distance with confidence.

Fixes #12

## Test plan
- [x] `pytest tests/test_asr.py` — 152 passed (includes new `_download_model` URL-selection tests for both `nemo_ctc` targets, and a `main()`-level test asserting `--model-type nemo_ctc --offline` resolves to the medium English target)
- [x] Verified both release assets resolve (HTTP 206 on ranged GET) before wiring in the URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add NeMo English Conformer CTC models to the ASR auto-download registry and make the medium English model the default for nemo_ctc, while keeping German as the language-specific alternative.

New Features:
- Introduce medium and small NeMo English Conformer CTC models as offline ASR options with auto-download support.
- Allow selecting the lighter NeMo CTC English small variant via explicit model directory configuration.

Enhancements:
- Update default model resolution so nemo_ctc chooses the English medium model by default and the German model when language is set to de.
- Extend the model download dispatcher and extraction mapping to handle the new NeMo CTC English targets.

Documentation:
- Document the NeMo CTC English medium and small models in ASR_MODEL.md, including auto-download behavior and usage examples.

Tests:
- Add tests covering URL selection for the NeMo CTC English medium and small models and verifying nemo_ctc defaults to the English medium target in offline mode.