### PR TITLE
update

### DIFF
--- a/sherox/asr.py
+++ b/sherox/asr.py
@@ -101,6 +101,7 @@ from types import SimpleNamespace
 from rich.console import Console
 
 from . import ConfigError
+from . import model_cache
 from .asr_engine import build_diarization, build_offline_recognizer, build_punctuation, build_recognizer, build_vad
 from .utils import download_file as _download_file
 from .utils import run_cli as _run_cli
@@ -754,8 +755,7 @@ def _download_model(model_dir: str, model_type: str) -> None:
 
 
 def _validate_model(model_dir: str, model_type: str) -> None:
-    if not Path(model_dir).is_dir():
-        _download_model(model_dir, model_type)
+    model_cache.ensure_model(model_dir, model_type, _download_model)
 
 
 def _normalize_language(language: str) -> str:

--- a/sherox/asr_engine.py
+++ b/sherox/asr_engine.py
@@ -197,6 +197,12 @@ def ensure_model_dir(model_dir: str, model_type: str = "") -> str:
     For library consumers (e.g. proscor) that want the same "auto-download
     into models/ on first use" behavior as the sherox CLI without
     reimplementing the download/extraction logic themselves.
+
+    `model_type` defaults to "" (auto-detect from `model_dir`'s basename,
+    same as omitting --model-type on the CLI). Pass it explicitly whenever
+    `model_dir`'s name doesn't already identify the model — otherwise
+    `_download_model` may fall back to sherox's default English model
+    instead of the one you intended.
     """
     from . import model_cache
     from .asr import _download_model

--- a/sherox/asr_engine.py
+++ b/sherox/asr_engine.py
@@ -184,6 +184,23 @@ def build_recognizer(cfg: Config):
     )
 
 
+def ensure_model_dir(model_dir: str, model_type: str = "") -> str:
+    """Ensure `model_dir` exists, auto-downloading it via sherox's model
+    registry (the same one `sherox.asr`'s CLI uses) if missing. Downloads are
+    shared across every project on this machine via `sherox.model_cache` — if
+    another project already downloaded this model, it's symlinked in instead
+    of being fetched again.
+
+    For library consumers (e.g. proscor) that want the same "auto-download
+    into models/ on first use" behavior as the sherox CLI without
+    reimplementing the download/extraction logic themselves.
+    """
+    from . import model_cache
+    from .asr import _download_model
+
+    return model_cache.ensure_model(model_dir, model_type, _download_model)
+
+
 def build_offline_recognizer(cfg: Config):
     """Load a Sherpa-ONNX offline recognizer for any supported offline model type.
 

--- a/sherox/model_cache.py
+++ b/sherox/model_cache.py
@@ -82,23 +82,39 @@ def migrate(project_dir: Path, model_type: str = "") -> None:
 
 def _relink(project_dir: Path, cached_dir: Path) -> None:
     project_dir.parent.mkdir(parents=True, exist_ok=True)
-    if project_dir.is_symlink() and not project_dir.exists():
+    if project_dir.is_symlink():
+        if project_dir.resolve() == cached_dir.resolve():
+            return  # already correctly linked
+        # Points somewhere else (stale target, or broken) — clear it so the
+        # symlink_to() below doesn't silently no-op and leave callers
+        # believing they got `cached_dir` when they didn't.
         project_dir.unlink()
-    if not project_dir.exists():
-        try:
-            project_dir.symlink_to(cached_dir, target_is_directory=True)
-        except OSError:
-            # Symlinks aren't available (e.g. no Developer Mode on Windows,
-            # or a filesystem like FAT32/exFAT that doesn't support them) —
-            # fall back to a real copy so the model is still usable.
-            shutil.copytree(cached_dir, project_dir)
+    elif project_dir.exists():
+        # An unexpected file or directory occupies the slot (e.g. a partial
+        # download from a crashed run) — clear it rather than leaving
+        # try_link() reporting success while `project_dir` isn't usable.
+        if project_dir.is_dir():
+            shutil.rmtree(project_dir)
+        else:
+            project_dir.unlink()
+    try:
+        project_dir.symlink_to(cached_dir, target_is_directory=True)
+    except OSError:
+        # Symlinks aren't available (e.g. no Developer Mode on Windows,
+        # or a filesystem like FAT32/exFAT that doesn't support them) —
+        # fall back to a real copy so the model is still usable.
+        shutil.copytree(cached_dir, project_dir)
 
 
 def ensure_model(model_dir: str, model_type: str, download_fn: Callable[[str, str], None]) -> str:
     """Ensure `model_dir` exists: untouched if already a real directory,
     symlinked if another project already cached it, or freshly downloaded
     via `download_fn(model_dir, model_type)` and then migrated into the
-    shared cache for reuse by sibling projects."""
+    shared cache for reuse by sibling projects.
+
+    Raises FileNotFoundError if `download_fn` returns without producing a
+    directory at `model_dir` — callers must not be handed a path that
+    doesn't actually contain a model."""
     path = Path(model_dir)
     if path.is_dir():
         return str(path)
@@ -107,7 +123,12 @@ def ensure_model(model_dir: str, model_type: str, download_fn: Callable[[str, st
 
     download_fn(model_dir, model_type)
 
-    if path.is_dir() and not path.is_symlink():
+    if not path.is_dir():
+        raise FileNotFoundError(
+            f"download_fn did not produce a model directory at '{path}'"
+        )
+
+    if not path.is_symlink():
         migrate(path, model_type)
 
     return str(path)

--- a/sherox/model_cache.py
+++ b/sherox/model_cache.py
@@ -10,7 +10,9 @@ each project's `models/<name>` becomes a symlink into it.
 
 Override the cache location with the `SHEROX_CACHE_DIR` env var.
 """
+import errno
 import os
+import shutil
 from pathlib import Path
 from typing import Callable
 
@@ -23,34 +25,58 @@ def cache_root() -> Path:
     return Path(base) / "sherox" / "models"
 
 
-def try_link(project_dir: Path) -> bool:
-    """If a cached copy of `project_dir.name` exists, symlink `project_dir`
-    to it and return True. Returns False (no-op) if nothing is cached yet."""
-    cached = cache_root() / project_dir.name
+def _cache_key(project_dir: Path, model_type: str) -> str:
+    """`model_type` is folded into the key because different model types can
+    land in identically-named project directories (e.g. a generic `models/model`
+    override), which would otherwise collide in the shared cache."""
+    return f"{model_type}__{project_dir.name}" if model_type else project_dir.name
+
+
+def try_link(project_dir: Path, model_type: str = "") -> bool:
+    """If a cached copy keyed by `project_dir` (and `model_type`) exists,
+    symlink `project_dir` to it and return True. Returns False (no-op) if
+    nothing is cached yet, or if the cache entry exists but isn't a usable
+    directory (e.g. a plain file or a broken symlink left over from a
+    previous failure)."""
+    cached = cache_root() / _cache_key(project_dir, model_type)
     if not cached.is_dir():
         return False
     _relink(project_dir, cached)
     return True
 
 
-def migrate(project_dir: Path) -> None:
+def migrate(project_dir: Path, model_type: str = "") -> None:
     """Move an already-downloaded `project_dir` into the shared cache and
     replace it with a symlink, so sibling projects reuse it instead of
     downloading their own copy. No-op if `project_dir` is already a symlink
     (e.g. a previous migration already ran)."""
     if project_dir.is_symlink():
         return
-    cached = cache_root() / project_dir.name
+    cached = cache_root() / _cache_key(project_dir, model_type)
     if cached.is_dir():
         # Another project already populated the cache for this model
         # first (race or pre-existing migration) — reuse it and drop this
         # copy rather than overwriting the cache.
-        import shutil
-
         shutil.rmtree(project_dir)
     else:
+        if cached.exists() or cached.is_symlink():
+            # A file or broken symlink occupies the cache slot — clear it
+            # rather than silently failing to migrate.
+            cached.unlink()
         cached.parent.mkdir(parents=True, exist_ok=True)
-        project_dir.rename(cached)
+        try:
+            project_dir.rename(cached)
+        except OSError as exc:
+            if exc.errno != errno.EXDEV:
+                raise
+            # project_dir and the cache root are on different filesystems
+            # (e.g. Docker overlay mounts) — rename() can't do a cross-device
+            # move, so copy the bytes across and drop the original.
+            try:
+                shutil.copytree(project_dir, cached)
+            except FileExistsError:
+                pass  # a concurrent migrate() populated it first
+            shutil.rmtree(project_dir)
     _relink(project_dir, cached)
 
 
@@ -59,7 +85,13 @@ def _relink(project_dir: Path, cached_dir: Path) -> None:
     if project_dir.is_symlink() and not project_dir.exists():
         project_dir.unlink()
     if not project_dir.exists():
-        project_dir.symlink_to(cached_dir, target_is_directory=True)
+        try:
+            project_dir.symlink_to(cached_dir, target_is_directory=True)
+        except OSError:
+            # Symlinks aren't available (e.g. no Developer Mode on Windows,
+            # or a filesystem like FAT32/exFAT that doesn't support them) —
+            # fall back to a real copy so the model is still usable.
+            shutil.copytree(cached_dir, project_dir)
 
 
 def ensure_model(model_dir: str, model_type: str, download_fn: Callable[[str, str], None]) -> str:
@@ -70,12 +102,12 @@ def ensure_model(model_dir: str, model_type: str, download_fn: Callable[[str, st
     path = Path(model_dir)
     if path.is_dir():
         return str(path)
-    if try_link(path):
+    if try_link(path, model_type):
         return str(path)
 
     download_fn(model_dir, model_type)
 
     if path.is_dir() and not path.is_symlink():
-        migrate(path)
+        migrate(path, model_type)
 
     return str(path)

--- a/sherox/model_cache.py
+++ b/sherox/model_cache.py
@@ -1,0 +1,81 @@
+"""Cross-project model cache.
+
+Downloaded model directories are large (tens of MB to 1 GB+) and often
+identical across every project that depends on sherox — e.g. two sibling
+repos both pulling in the Parakeet TDT ASR model or the same Piper TTS
+voice. Rather than each project's local `models/` holding its own full
+copy, the bytes live once in a shared cache (mirroring how
+`huggingface_hub` caches downloads under `~/.cache/huggingface/hub`) and
+each project's `models/<name>` becomes a symlink into it.
+
+Override the cache location with the `SHEROX_CACHE_DIR` env var.
+"""
+import os
+from pathlib import Path
+from typing import Callable
+
+
+def cache_root() -> Path:
+    override = os.environ.get("SHEROX_CACHE_DIR")
+    if override:
+        return Path(override)
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "sherox" / "models"
+
+
+def try_link(project_dir: Path) -> bool:
+    """If a cached copy of `project_dir.name` exists, symlink `project_dir`
+    to it and return True. Returns False (no-op) if nothing is cached yet."""
+    cached = cache_root() / project_dir.name
+    if not cached.is_dir():
+        return False
+    _relink(project_dir, cached)
+    return True
+
+
+def migrate(project_dir: Path) -> None:
+    """Move an already-downloaded `project_dir` into the shared cache and
+    replace it with a symlink, so sibling projects reuse it instead of
+    downloading their own copy. No-op if `project_dir` is already a symlink
+    (e.g. a previous migration already ran)."""
+    if project_dir.is_symlink():
+        return
+    cached = cache_root() / project_dir.name
+    if cached.is_dir():
+        # Another project already populated the cache for this model
+        # first (race or pre-existing migration) — reuse it and drop this
+        # copy rather than overwriting the cache.
+        import shutil
+
+        shutil.rmtree(project_dir)
+    else:
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        project_dir.rename(cached)
+    _relink(project_dir, cached)
+
+
+def _relink(project_dir: Path, cached_dir: Path) -> None:
+    project_dir.parent.mkdir(parents=True, exist_ok=True)
+    if project_dir.is_symlink() and not project_dir.exists():
+        project_dir.unlink()
+    if not project_dir.exists():
+        project_dir.symlink_to(cached_dir, target_is_directory=True)
+
+
+def ensure_model(model_dir: str, model_type: str, download_fn: Callable[[str, str], None]) -> str:
+    """Ensure `model_dir` exists: untouched if already a real directory,
+    symlinked if another project already cached it, or freshly downloaded
+    via `download_fn(model_dir, model_type)` and then migrated into the
+    shared cache for reuse by sibling projects."""
+    path = Path(model_dir)
+    if path.is_dir():
+        return str(path)
+    if try_link(path):
+        return str(path)
+
+    download_fn(model_dir, model_type)
+
+    if path.is_dir() and not path.is_symlink():
+        migrate(path)
+
+    return str(path)

--- a/sherox/tts.py
+++ b/sherox/tts.py
@@ -748,6 +748,11 @@ def _ensure_model(lang: str, model_dir: Optional[Path], project_dir: Path) -> Pa
     if target_dir.is_dir():
         return target_dir
 
+    from . import model_cache
+
+    if model_cache.try_link(target_dir):
+        return target_dir
+
     # Download and extract
     models_root.mkdir(parents=True, exist_ok=True)
     archive = models_root / meta["archive"]
@@ -769,6 +774,7 @@ def _ensure_model(lang: str, model_dir: Optional[Path], project_dir: Path) -> Pa
     if not target_dir.is_dir():
         _error(f"Expected model directory not found after extraction: {target_dir}")
 
+    model_cache.migrate(target_dir)
     _info(f"Model saved to '{target_dir}'.\n")
     return target_dir
 

--- a/sherox/tts.py
+++ b/sherox/tts.py
@@ -750,7 +750,7 @@ def _ensure_model(lang: str, model_dir: Optional[Path], project_dir: Path) -> Pa
 
     from . import model_cache
 
-    if model_cache.try_link(target_dir):
+    if model_cache.try_link(target_dir, f"tts_{lang}"):
         return target_dir
 
     # Download and extract
@@ -774,7 +774,7 @@ def _ensure_model(lang: str, model_dir: Optional[Path], project_dir: Path) -> Pa
     if not target_dir.is_dir():
         _error(f"Expected model directory not found after extraction: {target_dir}")
 
-    model_cache.migrate(target_dir)
+    model_cache.migrate(target_dir, f"tts_{lang}")
     _info(f"Model saved to '{target_dir}'.\n")
     return target_dir
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Add repo root so `from sherox.x import ...` works without installing the package.
@@ -8,3 +10,10 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 # Allow test modules to import from benchmark/
 sys.path.insert(0, str(_REPO_ROOT / "benchmark"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_model_cache(tmp_path_factory, monkeypatch):
+    """Point sherox.model_cache at a throwaway dir so no test ever migrates
+    fake/mocked model directories into the real ~/.cache/sherox/models."""
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path_factory.mktemp("sherox_cache")))

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -394,10 +394,14 @@ class TestValidateModel:
         mock_dl.assert_not_called()
 
     def test_downloads_when_dir_missing(self, tmp_path):
-        missing = str(tmp_path / "no_such_dir")
-        with patch.object(main_module, "_download_model") as mock_dl:
-            main_module._validate_model(missing, "zipformer2")
-        mock_dl.assert_called_once_with(missing, "zipformer2")
+        missing = tmp_path / "no_such_dir"
+
+        def _fake_download(model_dir, model_type):
+            Path(model_dir).mkdir(parents=True)
+
+        with patch.object(main_module, "_download_model", side_effect=_fake_download) as mock_dl:
+            main_module._validate_model(str(missing), "zipformer2")
+        mock_dl.assert_called_once_with(str(missing), "zipformer2")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,0 +1,235 @@
+import errno
+from pathlib import Path
+
+import pytest
+
+from sherox import model_cache
+
+
+def _make_dir(path, filename="f.txt", content="hi"):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / filename).write_text(content)
+    return path
+
+
+def test_cache_root_honors_sherox_cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "custom"))
+    assert model_cache.cache_root() == tmp_path / "custom"
+
+
+def test_cache_root_falls_back_to_xdg_cache_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("SHEROX_CACHE_DIR", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert model_cache.cache_root() == tmp_path / "xdg" / "sherox" / "models"
+
+
+def test_cache_key_includes_model_type(tmp_path):
+    project_dir = tmp_path / "models" / "current"
+    assert model_cache._cache_key(project_dir, "nemo_ctc") == "nemo_ctc__current"
+    assert model_cache._cache_key(project_dir, "multilingual_streaming") != (
+        model_cache._cache_key(project_dir, "nemo_ctc")
+    )
+    # No model_type given: key is just the directory name (backward compatible).
+    assert model_cache._cache_key(project_dir, "") == "current"
+
+
+def test_try_link_no_cache_entry_is_noop(tmp_path):
+    project_dir = tmp_path / "proj" / "models" / "foo"
+    assert model_cache.try_link(project_dir, "asr") is False
+    assert not project_dir.exists()
+
+
+def test_try_link_links_existing_cache_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cached = _make_dir(tmp_path / "cache" / "asr__foo")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+
+    assert model_cache.try_link(project_dir, "asr") is True
+    assert project_dir.is_symlink()
+    assert project_dir.resolve() == cached.resolve()
+    assert (project_dir / "f.txt").read_text() == "hi"
+
+
+def test_try_link_ignores_cache_entry_that_is_a_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cache_slot = tmp_path / "cache" / "asr__foo"
+    cache_slot.parent.mkdir(parents=True)
+    cache_slot.write_text("not a directory")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+
+    assert model_cache.try_link(project_dir, "asr") is False
+    assert not project_dir.exists()
+
+
+def test_migrate_moves_into_cache_and_symlinks(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    project_dir = _make_dir(tmp_path / "proj" / "models" / "foo")
+
+    model_cache.migrate(project_dir, "asr")
+
+    assert project_dir.is_symlink()
+    cached = tmp_path / "cache" / "asr__foo"
+    assert cached.is_dir()
+    assert (project_dir / "f.txt").read_text() == "hi"
+
+
+def test_migrate_is_noop_when_already_symlink(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cached = _make_dir(tmp_path / "cache" / "asr__foo")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+    project_dir.parent.mkdir(parents=True)
+    project_dir.symlink_to(cached, target_is_directory=True)
+
+    model_cache.migrate(project_dir, "asr")  # should not raise or touch anything
+
+    assert project_dir.resolve() == cached.resolve()
+
+
+def test_migrate_drops_local_copy_when_cache_already_populated(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cached = _make_dir(tmp_path / "cache" / "asr__foo", content="cached-version")
+    project_dir = _make_dir(tmp_path / "proj" / "models" / "foo", content="local-version")
+
+    model_cache.migrate(project_dir, "asr")
+
+    assert project_dir.is_symlink()
+    # The pre-existing cache content wins; the local copy was discarded.
+    assert (project_dir / "f.txt").read_text() == "cached-version"
+    assert cached.is_dir()
+
+
+def test_migrate_clears_stale_file_occupying_cache_slot(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cache_slot = tmp_path / "cache" / "asr__foo"
+    cache_slot.parent.mkdir(parents=True)
+    cache_slot.write_text("stray file")
+    project_dir = _make_dir(tmp_path / "proj" / "models" / "foo", content="real-model")
+
+    model_cache.migrate(project_dir, "asr")
+
+    assert project_dir.is_symlink()
+    assert cache_slot.is_dir()
+    assert (project_dir / "f.txt").read_text() == "real-model"
+
+
+def test_migrate_falls_back_to_copy_on_cross_device_rename(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    project_dir = _make_dir(tmp_path / "proj" / "models" / "foo")
+
+    def _raise_exdev(self, target):
+        raise OSError(errno.EXDEV, "cross-device link")
+
+    monkeypatch.setattr(Path, "rename", _raise_exdev)
+
+    model_cache.migrate(project_dir, "asr")
+
+    assert project_dir.is_symlink()
+    cached = tmp_path / "cache" / "asr__foo"
+    assert cached.is_dir()
+    assert (project_dir / "f.txt").read_text() == "hi"
+
+
+def test_migrate_reraises_non_exdev_oserror(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    project_dir = _make_dir(tmp_path / "proj" / "models" / "foo")
+
+    def _raise_other(self, target):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(Path, "rename", _raise_other)
+
+    with pytest.raises(OSError):
+        model_cache.migrate(project_dir, "asr")
+
+
+def test_relink_replaces_symlink_pointing_elsewhere(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    wrong_target = _make_dir(tmp_path / "wrong", content="wrong")
+    cached = _make_dir(tmp_path / "cache" / "asr__foo", content="correct")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+    project_dir.parent.mkdir(parents=True)
+    project_dir.symlink_to(wrong_target, target_is_directory=True)
+
+    model_cache._relink(project_dir, cached)
+
+    assert project_dir.resolve() == cached.resolve()
+    assert (project_dir / "f.txt").read_text() == "correct"
+
+
+def test_relink_replaces_stray_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cached = _make_dir(tmp_path / "cache" / "asr__foo", content="correct")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+    project_dir.parent.mkdir(parents=True)
+    project_dir.write_text("stray file")
+
+    model_cache._relink(project_dir, cached)
+
+    assert project_dir.is_symlink()
+    assert (project_dir / "f.txt").read_text() == "correct"
+
+
+def test_relink_falls_back_to_copy_when_symlinks_unsupported(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    cached = _make_dir(tmp_path / "cache" / "asr__foo", content="correct")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+
+    def _raise_oserror(self, target, target_is_directory=False):
+        raise OSError("symlinks not supported")
+
+    monkeypatch.setattr(Path, "symlink_to", _raise_oserror)
+
+    model_cache._relink(project_dir, cached)
+
+    assert project_dir.is_dir()
+    assert not project_dir.is_symlink()
+    assert (project_dir / "f.txt").read_text() == "correct"
+
+
+def test_ensure_model_returns_existing_directory_without_downloading(tmp_path):
+    project_dir = _make_dir(tmp_path / "proj" / "models" / "foo")
+    calls = []
+
+    result = model_cache.ensure_model(
+        str(project_dir), "asr", lambda d, t: calls.append((d, t))
+    )
+
+    assert result == str(project_dir)
+    assert calls == []
+
+
+def test_ensure_model_links_from_cache_without_downloading(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    _make_dir(tmp_path / "cache" / "asr__foo")
+    project_dir = tmp_path / "proj" / "models" / "foo"
+    calls = []
+
+    result = model_cache.ensure_model(
+        str(project_dir), "asr", lambda d, t: calls.append((d, t))
+    )
+
+    assert result == str(project_dir)
+    assert project_dir.is_symlink()
+    assert calls == []
+
+
+def test_ensure_model_downloads_and_migrates(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    project_dir = tmp_path / "proj" / "models" / "foo"
+
+    def _download(model_dir, model_type):
+        _make_dir(Path(model_dir))
+
+    result = model_cache.ensure_model(str(project_dir), "asr", _download)
+
+    assert result == str(project_dir)
+    assert project_dir.is_symlink()
+    assert (tmp_path / "cache" / "asr__foo").is_dir()
+
+
+def test_ensure_model_raises_when_download_fn_does_not_create_directory(tmp_path, monkeypatch):
+    monkeypatch.setenv("SHEROX_CACHE_DIR", str(tmp_path / "cache"))
+    project_dir = tmp_path / "proj" / "models" / "foo"
+
+    with pytest.raises(FileNotFoundError):
+        model_cache.ensure_model(str(project_dir), "asr", lambda d, t: None)


### PR DESCRIPTION
## Summary by Sourcery

Introduce a shared cross-project model cache for ASR/TTS models and wire core model-loading paths and tests to use it safely.

New Features:
- Add a model_cache module that centralizes shared storage and symlinking of downloaded model directories across projects.
- Expose an ensure_model_dir helper so library consumers can auto-download ASR models into local directories using the shared cache.

Enhancements:
- Update ASR and TTS model validation/loading to reuse the shared cache when possible and migrate newly downloaded models into it for future reuse.

Tests:
- Add an autouse pytest fixture to isolate the sherox model cache during tests by redirecting it to a temporary directory.